### PR TITLE
fixed proxy variable type to be string always

### DIFF
--- a/mopidy_radio_de/actor.py
+++ b/mopidy_radio_de/actor.py
@@ -25,7 +25,7 @@ def format_proxy(scheme, username, password, hostname, port):
         else:
             return "%s://%s:%i" % (scheme, hostname, port)
     else:
-        return None
+        return ""
 
 
 class RadioDeBackend(pykka.ThreadingActor, backend.Backend):


### PR DESCRIPTION
This should fix issue #11. Returning type None and then asking its length causes problems. Returning a length 0 string is probably the shortest fix that can be accomplished.
